### PR TITLE
Update DB `eddsa-2022` issuer.

### DIFF
--- a/implementations/DigitalBazaar.json
+++ b/implementations/DigitalBazaar.json
@@ -2,11 +2,11 @@
   "name": "Digital Bazaar",
   "implementation": "Veres One (Q/A)",
   "issuers": [{
-    "id": "https://issuer.qa.veres.app/issuers/z19vAK3wcvD1sX4FnmSGbT4VX",
-    "endpoint": "https://issuer.qa.veres.app/issuers/z19vAK3wcvD1sX4FnmSGbT4VX/credentials/issue",
+    "id": "https://issuer.qa.veres.app/issuers/z1A4Z2Mc6W2uW27cpSv6VA9Nw",
+    "endpoint": "https://issuer.qa.veres.app/issuers/z1A4Z2Mc6W2uW27cpSv6VA9Nw/credentials/issue",
     "method": "POST",
     "zcap": {
-      "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:f06e7b2e-fe48-449e-9435-0c3c4051c5a8\",\"controller\":\"did:key:z6MkptjaoxjyKQFSqf1dHXswP6EayYhPQBYzprVCPmGBHz9S\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz19vAK3wcvD1sX4FnmSGbT4VX\",\"invocationTarget\":\"https://issuer.qa.veres.app/issuers/z19vAK3wcvD1sX4FnmSGbT4VX/credentials\",\"expires\":\"2023-09-29T15:04:45Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2022-09-29T15:04:45Z\",\"verificationMethod\":\"did:key:z6MkriDnfJttUyRv8HQSRmxVGFgpVV6GoUTn5De5E1VC6Hzs#z6MkriDnfJttUyRv8HQSRmxVGFgpVV6GoUTn5De5E1VC6Hzs\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz19vAK3wcvD1sX4FnmSGbT4VX\"],\"proofValue\":\"z7KmoPxkjQc1nJmyzo4nJSiPaowcdPDtM9SJydd8herRy9d2NAehyP1kFtHwgWpM2ZUd8nMwgJnDUo688eKXErQ9\"}}",
+      "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:e58dee27-cae3-4f57-8790-ecf9d1dff3de\",\"controller\":\"did:key:z6MkptjaoxjyKQFSqf1dHXswP6EayYhPQBYzprVCPmGBHz9S\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz1A4Z2Mc6W2uW27cpSv6VA9Nw\",\"invocationTarget\":\"https://issuer.qa.veres.app/issuers/z1A4Z2Mc6W2uW27cpSv6VA9Nw/credentials/issue\",\"expires\":\"2024-10-24T18:43:21Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2023-10-25T18:43:22Z\",\"verificationMethod\":\"did:key:z6MkkkanLE2mcwABMS3RrN4S81E5zo3SSjo7Lc6EBKB4w5ck#z6MkkkanLE2mcwABMS3RrN4S81E5zo3SSjo7Lc6EBKB4w5ck\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz1A4Z2Mc6W2uW27cpSv6VA9Nw\"],\"proofValue\":\"zVt5yXHVY9xtsV1AmDVTuoL3NnzdFQrKVhk8yuSL1q5USwuZpF37FKD84HTSAwWkRabmHcHoiKouqQPQ7WtwMAr3\"}}",
       "keySeed": "KEY_SEED_DB"
     },
     "tags": ["eddsa-2022"]


### PR DESCRIPTION
The previous instance had expired zcaps and so was giving a 500 unspecified error when issuing credentials.

This update has been tested with `vc-di-eddsa-2022-test-suite`.  DB issuance tests are passing with this update.
```
Tests passed 161/164 98%
Tests failed 3/164 2%
Failures 3
Tests skipped 0
Total tests 164
```