### PR TITLE
Update tag names for ecdsa and eddsa test suites.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,18 +137,18 @@ module.exports = [{
 
 Tags tell the test suites which implementations to run the test suites against.
 
-`vc2.0` - This tag will run the [VC Data Model 2.0 Test Suite](https://github.com/digitalbazaar/vc-data-model-2-test-suite) on your issuer and verifier endpoints.
+* `vc2.0` - This tag will run the [VC Data Model 2.0 Test Suite](https://github.com/w3c/vc-data-model-2.0-test-suite) on your issuer and verifier endpoints.
 
-`Ed25519Signature2020` - This tag will run the [Ed25519 tests](https://github.com/w3c-ccg/di-ed25519-test-suite) on either your issuer and/or verifier.
+* `Ed25519Signature2020` - This tag will run the [Ed25519 tests](https://github.com/w3c/vc-di-ed25519signature2020-test-suite) on either your issuer and/or verifier.
 
-`ecdsa-rdfc-2019` or `ecdsa-sd-2023` - These tags will run
-the [VC Data Integrity ECDSA Test Suite](https://github.com/w3c-ccg/vc-di-ecdsa-test-suite) on your issuer and verifier endpoints.
-Note: Along with the cryptosuite tag, for you should also specify the
-`supportedEcdsaKeyTypes` (ECDSA key types that your implementation issues or
-can verify). Currently, the test suite supports `P-256` and `P-384` ECDSA key
-types.
+* `ecdsa-rdfc-2019` or `ecdsa-sd-2023` - These tags will run the
+[VC Data Integrity ECDSA Test Suite](https://github.com/w3c/vc-di-ecdsa-test-suite)
+on your issuer and verifier endpoints.
+  * Alongside this cryptosuite tag, you must also specify the `supportedEcdsaKeyTypes`
+  key parallel to `tags` listing the ECDSA key types that your implementation issues or
+  can verify. Currently, the test suite supports `P-256` and `P-384` ECDSA key types.
 
-`eddsa-rdfc-2022` - This tag will run the [VC Data Integrity EDDSA Test Suite](https://github.com/w3c-ccg/di-eddsa-2022-test-suite) on your issuer and verifier endpoints.
+* `eddsa-rdfc-2022` - This tag will run the [VC Data Integrity EDDSA Test Suite](https://github.com/w3c/vc-di-eddsa-test-suite) on your issuer and verifier endpoints.
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ following form:
       "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:4d44084c-334e-46dc-ac23-5e26f75262b6\",\"controller\":\"did:key:zFoo\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fmy.implementation.net%2Fissuers%2Fz19wCeJafpsTzvA6hZksz7TYF\",\"invocationTarget\":\"https://my.implementation.net/issuers/z19wCeJafpsTzvA6hZksz7TYF/credentials/issue\",\"expires\":\"2022-05-29T17:26:30Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2022-02-28T17:26:30Z\",\"verificationMethod\":\"did:key:z6Mkk2x1J4jCmaHDyYRRW1NB7CzeKYbjo3boGfRiefPzZjLQ#z6Mkk2x1J4jCmaHDyYRRW1NB7CzeKYbjo3boGfRiefPzZjLQ\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fmy.implementation.net%2Fissuers%2Fz19wCeJafpsTzvA6hZksz7TYF\"],\"proofValue\":\"zBar\"}}",
       "keySeed": "KEY_SEED_DB"
     },
-    "tags": ["ecdsa-rdfc-2019"]
+    "tags": ["ecdsa-rdfc-2019", "P-256"]
   }],
   "verifiers": [{
     "id": "https://product.example.com/verifiers/z19uokPn3b1Z4XDbQSHo7VhFR",
@@ -137,7 +137,10 @@ vc2.0 - This tag will run the [VC Data Model 2.0 Test Suite](https://github.com/
 
 Ed25519Signature2020 - This tag will run the [Ed25519 tests](https://github.com/w3c-ccg/di-ed25519-test-suite) on either your issuer and/or verifier.
 
-ecdsa-rdfc-2019 - This tag will run the [VC Data Integrity ECDSA Test Suite](https://github.com/w3c-ccg/vc-di-ecdsa-test-suite) on your issuer and verifier endpoints.
+ecdsa-rdfc-2019 - This tag will run the [VC Data Integrity ECDSA Test Suite](https://github.com/w3c-ccg/vc-di-ecdsa-test-suite) on your issuer and verifier endpoints. Along
+with the cryptosuite tag, for the issuers you should also specify the key type
+that your implementation supports. Currently, the test suite supports `P-256`
+and `P-384` keyTypes.
 
 eddsa-rdfc-2022 - This tag will run the [VC Data Integrity EDDSA Test Suite](https://github.com/w3c-ccg/di-eddsa-2022-test-suite) on your issuer and verifier endpoints.
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ module.exports = [{
     "id": "urn:uuid:my:implementation:issuer:id",
     "endpoint": "https://localhost:40443/issuers/foo/credentials/issue",
     "method": "POST",
-    "tags": ["ecdsa-rdfc-2019", "localhost"]
+    "tags": ["ecdsa-rdfc-2019", "P-256", "localhost"]
   }],
   "verifiers": [{
     "id": "https://localhost:40443/verifiers/z19uokPn3b1Z4XDbQSHo7VhFR",
@@ -133,16 +133,17 @@ module.exports = [{
 
 Tags tell the test suites which implementations to run the test suites against.
 
-vc2.0 - This tag will run the [VC Data Model 2.0 Test Suite](https://github.com/digitalbazaar/vc-data-model-2-test-suite) on your issuer and verifier endpoints.
+`vc2.0` - This tag will run the [VC Data Model 2.0 Test Suite](https://github.com/digitalbazaar/vc-data-model-2-test-suite) on your issuer and verifier endpoints.
 
-Ed25519Signature2020 - This tag will run the [Ed25519 tests](https://github.com/w3c-ccg/di-ed25519-test-suite) on either your issuer and/or verifier.
+`Ed25519Signature2020` - This tag will run the [Ed25519 tests](https://github.com/w3c-ccg/di-ed25519-test-suite) on either your issuer and/or verifier.
 
-ecdsa-rdfc-2019 - This tag will run the [VC Data Integrity ECDSA Test Suite](https://github.com/w3c-ccg/vc-di-ecdsa-test-suite) on your issuer and verifier endpoints. Along
-with the cryptosuite tag, for the issuers you should also specify the key type
-that your implementation supports. Currently, the test suite supports `P-256`
-and `P-384` keyTypes.
+`ecdsa-rdfc-2019` or `ecdsa-sd-2023` - These tags will run
+the [VC Data Integrity ECDSA Test Suite](https://github.com/w3c-ccg/vc-di-ecdsa-test-suite) on your issuer and verifier endpoints.
+Note: Along with the cryptosuite tag, for the issuers you should also specify
+the key type that your implementation supports in the tags. Currently, the test
+suite supports `P-256` and `P-384` key types.
 
-eddsa-rdfc-2022 - This tag will run the [VC Data Integrity EDDSA Test Suite](https://github.com/w3c-ccg/di-eddsa-2022-test-suite) on your issuer and verifier endpoints.
+`eddsa-rdfc-2022` - This tag will run the [VC Data Integrity EDDSA Test Suite](https://github.com/w3c-ccg/di-eddsa-2022-test-suite) on your issuer and verifier endpoints.
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ following form:
       "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:4d44084c-334e-46dc-ac23-5e26f75262b6\",\"controller\":\"did:key:zFoo\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fmy.implementation.net%2Fissuers%2Fz19wCeJafpsTzvA6hZksz7TYF\",\"invocationTarget\":\"https://my.implementation.net/issuers/z19wCeJafpsTzvA6hZksz7TYF/credentials/issue\",\"expires\":\"2022-05-29T17:26:30Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2022-02-28T17:26:30Z\",\"verificationMethod\":\"did:key:z6Mkk2x1J4jCmaHDyYRRW1NB7CzeKYbjo3boGfRiefPzZjLQ#z6Mkk2x1J4jCmaHDyYRRW1NB7CzeKYbjo3boGfRiefPzZjLQ\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fmy.implementation.net%2Fissuers%2Fz19wCeJafpsTzvA6hZksz7TYF\"],\"proofValue\":\"zBar\"}}",
       "keySeed": "KEY_SEED_DB"
     },
-    "tags": ["ecdsa-rdfc-2019", "P-256"]
+    "supportedEcdsaKeyTypes": ["P-256"]
+    "tags": ["ecdsa-rdfc-2019"]
   }],
   "verifiers": [{
     "id": "https://product.example.com/verifiers/z19uokPn3b1Z4XDbQSHo7VhFR",
@@ -89,6 +90,7 @@ following form:
       "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:41473f9f-9e44-4ac9-9ac2-c86a6f695703\",\"controller\":\"did:key:zFoo\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fmy.implementation.net%3A40443%2Fverifiers%2Fz19uokPn3b1Z4XDbQSHo7VhFR\",\"invocationTarget\":\"https://my.implementation.net/verifiers/zBar/credentials/verify\",\"expires\":\"2023-03-17T17:39:49Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2022-03-17T17:39:49Z\",\"verificationMethod\":\"did:key:zFoo#zBar\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fmy.application.net%2Fverifiers%2FzFoo\"],\"proofValue\":\"zBar\"}}",
       "keySeed": "KEY_SEED_DB"
     },
+    "supportedEcdsaKeyTypes": ["P-256"]
     "tags": ["ecdsa-rdfc-2019"]
   }]
 }
@@ -118,12 +120,14 @@ module.exports = [{
     "id": "urn:uuid:my:implementation:issuer:id",
     "endpoint": "https://localhost:40443/issuers/foo/credentials/issue",
     "method": "POST",
-    "tags": ["ecdsa-rdfc-2019", "P-256", "localhost"]
+    "supportedEcdsaKeyTypes": ["P-256"]
+    "tags": ["ecdsa-rdfc-2019", "localhost"]
   }],
   "verifiers": [{
     "id": "https://localhost:40443/verifiers/z19uokPn3b1Z4XDbQSHo7VhFR",
     "endpoint": "https://localhost:40443/verifiers/z19uokPn3b1Z4XDbQSHo7VhFR/credentials/verify",
     "method": "POST",
+    "supportedEcdsaKeyTypes": ["P-256", "P-384"]
     "tags": ["ecdsa-rdfc-2019", "localhost"]
   }]
 }];
@@ -139,9 +143,10 @@ Tags tell the test suites which implementations to run the test suites against.
 
 `ecdsa-rdfc-2019` or `ecdsa-sd-2023` - These tags will run
 the [VC Data Integrity ECDSA Test Suite](https://github.com/w3c-ccg/vc-di-ecdsa-test-suite) on your issuer and verifier endpoints.
-Note: Along with the cryptosuite tag, for the issuers you should also specify
-the key type that your implementation supports in the tags. Currently, the test
-suite supports `P-256` and `P-384` key types.
+Note: Along with the cryptosuite tag, for you should also specify the
+`supportedEcdsaKeyTypes` (ECDSA key types that your implementation issues or
+can verify). Currently, the test suite supports `P-256` and `P-384` ECDSA key
+types.
 
 `eddsa-rdfc-2022` - This tag will run the [VC Data Integrity EDDSA Test Suite](https://github.com/w3c-ccg/di-eddsa-2022-test-suite) on your issuer and verifier endpoints.
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ following form:
       "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:4d44084c-334e-46dc-ac23-5e26f75262b6\",\"controller\":\"did:key:zFoo\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fmy.implementation.net%2Fissuers%2Fz19wCeJafpsTzvA6hZksz7TYF\",\"invocationTarget\":\"https://my.implementation.net/issuers/z19wCeJafpsTzvA6hZksz7TYF/credentials/issue\",\"expires\":\"2022-05-29T17:26:30Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2022-02-28T17:26:30Z\",\"verificationMethod\":\"did:key:z6Mkk2x1J4jCmaHDyYRRW1NB7CzeKYbjo3boGfRiefPzZjLQ#z6Mkk2x1J4jCmaHDyYRRW1NB7CzeKYbjo3boGfRiefPzZjLQ\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fmy.implementation.net%2Fissuers%2Fz19wCeJafpsTzvA6hZksz7TYF\"],\"proofValue\":\"zBar\"}}",
       "keySeed": "KEY_SEED_DB"
     },
-    "tags": ["ecdsa-2019"]
+    "tags": ["ecdsa-rdfc-2019"]
   }],
   "verifiers": [{
     "id": "https://product.example.com/verifiers/z19uokPn3b1Z4XDbQSHo7VhFR",
@@ -89,7 +89,7 @@ following form:
       "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:41473f9f-9e44-4ac9-9ac2-c86a6f695703\",\"controller\":\"did:key:zFoo\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fmy.implementation.net%3A40443%2Fverifiers%2Fz19uokPn3b1Z4XDbQSHo7VhFR\",\"invocationTarget\":\"https://my.implementation.net/verifiers/zBar/credentials/verify\",\"expires\":\"2023-03-17T17:39:49Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2022-03-17T17:39:49Z\",\"verificationMethod\":\"did:key:zFoo#zBar\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fmy.application.net%2Fverifiers%2FzFoo\"],\"proofValue\":\"zBar\"}}",
       "keySeed": "KEY_SEED_DB"
     },
-    "tags": ["ecdsa-2019"]
+    "tags": ["ecdsa-rdfc-2019"]
   }]
 }
 ```
@@ -118,13 +118,13 @@ module.exports = [{
     "id": "urn:uuid:my:implementation:issuer:id",
     "endpoint": "https://localhost:40443/issuers/foo/credentials/issue",
     "method": "POST",
-    "tags": ["ecdsa-2019", "localhost"]
+    "tags": ["ecdsa-rdfc-2019", "localhost"]
   }],
   "verifiers": [{
     "id": "https://localhost:40443/verifiers/z19uokPn3b1Z4XDbQSHo7VhFR",
     "endpoint": "https://localhost:40443/verifiers/z19uokPn3b1Z4XDbQSHo7VhFR/credentials/verify",
     "method": "POST",
-    "tags": ["ecdsa-2019", "localhost"]
+    "tags": ["ecdsa-rdfc-2019", "localhost"]
   }]
 }];
 ```
@@ -137,9 +137,9 @@ vc2.0 - This tag will run the [VC Data Model 2.0 Test Suite](https://github.com/
 
 Ed25519Signature2020 - This tag will run the [Ed25519 tests](https://github.com/w3c-ccg/di-ed25519-test-suite) on either your issuer and/or verifier.
 
-ecdsa-2019 - This tag will run the [VC Data Integrity ECDSA Test Suite](https://github.com/w3c-ccg/vc-di-ecdsa-test-suite) on your issuer and verifier endpoints.
+ecdsa-rdfc-2019 - This tag will run the [VC Data Integrity ECDSA Test Suite](https://github.com/w3c-ccg/vc-di-ecdsa-test-suite) on your issuer and verifier endpoints.
 
-eddsa-2022 - This tag will run the [VC Data Integrity EDDSA Test Suite](https://github.com/w3c-ccg/di-eddsa-2022-test-suite) on your issuer and verifier endpoints.
+eddsa-rdfc-2022 - This tag will run the [VC Data Integrity EDDSA Test Suite](https://github.com/w3c-ccg/di-eddsa-2022-test-suite) on your issuer and verifier endpoints.
 
 ## Contribute
 

--- a/implementations/ApiCatalog.json
+++ b/implementations/ApiCatalog.json
@@ -5,6 +5,7 @@
     "id": "https://vc.apicatalog.com",
     "endpoint": "https://vc.apicatalog.com/credentials/verify",
     "method": "POST",
+    "supportedEcdsaKeyTypes": ["P-256"],
     "tags": ["Ed25519Signature2020", "vc2.0", "eddsa-rdfc-2022", "ecdsa-rdfc-2019"]
   }],
   "issuers": [{
@@ -27,7 +28,8 @@
     "options": {
       "type": "ecdsa-2019"
     },
-    "tags": ["ecdsa-rdfc-2019", "P-256"]
+    "supportedEcdsaKeyTypes": ["P-256"],
+    "tags": ["ecdsa-rdfc-2019"]
   }],
   "vpVerifiers": [{
     "id": "https://vc.apicatalog.com",

--- a/implementations/ApiCatalog.json
+++ b/implementations/ApiCatalog.json
@@ -5,7 +5,7 @@
     "id": "https://vc.apicatalog.com",
     "endpoint": "https://vc.apicatalog.com/credentials/verify",
     "method": "POST",
-    "tags": ["Ed25519Signature2020", "vc2.0", "eddsa-2022", "ecdsa-2019" ]
+    "tags": ["Ed25519Signature2020", "vc2.0", "eddsa-rdfc-2022", "ecdsa-rdfc-2019"]
   }],
   "issuers": [{
     "id": "did:key:z6Mkska8oQD7QQQWxqa7L5ai4mH98HfAdSwomPFYKuqNyE2y",
@@ -20,19 +20,19 @@
     "options": {
       "type": "eddsa-2022"
     },
-    "tags": ["eddsa-2022"]
+    "tags": ["eddsa-rdfc-2022"]
   }, {
     "id": "did:key:zDnaepBuvsQ8cpsWrVKw8fbpGpvPeNSjVPTWoq6cRqaYzBKVP",
     "endpoint": "https://vc.apicatalog.com/credentials/issue",
     "options": {
       "type": "ecdsa-2019"
     },
-    "tags": ["ecdsa-2019" ]
+    "tags": ["ecdsa-rdfc-2019"]
   }],
   "vpVerifiers": [{
     "id": "https://vc.apicatalog.com",
     "endpoint": "https://vc.apicatalog.com/presentations/verify",
     "method": "POST",
-    "tags": ["Ed25519Signature2020", "vc2.0", "eddsa-2022", "ecdsa-2019" ]
+    "tags": ["Ed25519Signature2020", "vc2.0", "eddsa-rdfc-2022", "ecdsa-rdfc-2019"]
   }]
 }

--- a/implementations/ApiCatalog.json
+++ b/implementations/ApiCatalog.json
@@ -27,7 +27,7 @@
     "options": {
       "type": "ecdsa-2019"
     },
-    "tags": ["ecdsa-rdfc-2019"]
+    "tags": ["ecdsa-rdfc-2019", "P-256"]
   }],
   "vpVerifiers": [{
     "id": "https://vc.apicatalog.com",

--- a/implementations/DigitalBazaar.json
+++ b/implementations/DigitalBazaar.json
@@ -2,23 +2,41 @@
   "name": "Digital Bazaar",
   "implementation": "Veres One (Q/A)",
   "issuers": [{
-    "id": "https://issuer.qa.veres.app/issuers/z1A4Z2Mc6W2uW27cpSv6VA9Nw",
-    "endpoint": "https://issuer.qa.veres.app/issuers/z1A4Z2Mc6W2uW27cpSv6VA9Nw/credentials/issue",
+    "id": "https://issuer.qa.veres.app/issuers/z19rYvMxCQzMb9hQ7xuQ5ipJd",
+    "endpoint": "https://issuer.qa.veres.app/issuers/z19rYvMxCQzMb9hQ7xuQ5ipJd/credentials/issue",
     "method": "POST",
     "zcap": {
-      "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:e58dee27-cae3-4f57-8790-ecf9d1dff3de\",\"controller\":\"did:key:z6MkptjaoxjyKQFSqf1dHXswP6EayYhPQBYzprVCPmGBHz9S\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz1A4Z2Mc6W2uW27cpSv6VA9Nw\",\"invocationTarget\":\"https://issuer.qa.veres.app/issuers/z1A4Z2Mc6W2uW27cpSv6VA9Nw/credentials/issue\",\"expires\":\"2024-10-24T18:43:21Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2023-10-25T18:43:22Z\",\"verificationMethod\":\"did:key:z6MkkkanLE2mcwABMS3RrN4S81E5zo3SSjo7Lc6EBKB4w5ck#z6MkkkanLE2mcwABMS3RrN4S81E5zo3SSjo7Lc6EBKB4w5ck\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz1A4Z2Mc6W2uW27cpSv6VA9Nw\"],\"proofValue\":\"zVt5yXHVY9xtsV1AmDVTuoL3NnzdFQrKVhk8yuSL1q5USwuZpF37FKD84HTSAwWkRabmHcHoiKouqQPQ7WtwMAr3\"}}",
+      "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:10765250-c445-4672-8271-16a033d5fc51\",\"controller\":\"did:key:z6MkptjaoxjyKQFSqf1dHXswP6EayYhPQBYzprVCPmGBHz9S\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz19rYvMxCQzMb9hQ7xuQ5ipJd\",\"invocationTarget\":\"https://issuer.qa.veres.app/issuers/z19rYvMxCQzMb9hQ7xuQ5ipJd/credentials/issue\",\"expires\":\"2024-11-15T17:06:07Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2023-11-16T17:06:08Z\",\"verificationMethod\":\"did:key:z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b#z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz19rYvMxCQzMb9hQ7xuQ5ipJd\"],\"proofValue\":\"z55MhL1RCGvM1oLd9KqRwSP8rQu5wkr5tcyJbgi4CHvvvvhH65TxVATbHqLQT7b1zPZa7nbVCrUwSxwihoVCjrivU\"}}",
       "keySeed": "KEY_SEED_DB"
     },
-    "tags": ["eddsa-2022"]
+    "tags": ["eddsa-rdfc-2022"]
    }, {
-    "id": "https://issuer.qa.veres.app/issuers/z1ADcQsTdU2YPWsLJ6DWymumr",
-    "endpoint": "https://issuer.qa.veres.app/issuers/z1ADcQsTdU2YPWsLJ6DWymumr/credentials/issue",
+    "id": "https://issuer.qa.veres.app/issuers/z1ADd8YGQqDFrVDXb85City8t",
+    "endpoint": "https://issuer.qa.veres.app/issuers/z1ADd8YGQqDFrVDXb85City8t/credentials/issue",
     "method": "POST",
     "zcap": {
-      "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:6ac9904b-12c0-4f50-8871-eedd64fb337d\",\"controller\":\"did:key:z6MkptjaoxjyKQFSqf1dHXswP6EayYhPQBYzprVCPmGBHz9S\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz1ADcQsTdU2YPWsLJ6DWymumr\",\"invocationTarget\":\"https://issuer.qa.veres.app/issuers/z1ADcQsTdU2YPWsLJ6DWymumr/credentials\",\"expires\":\"2024-06-25T20:29:36Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2023-06-26T20:29:37Z\",\"verificationMethod\":\"did:key:z6MkkkanLE2mcwABMS3RrN4S81E5zo3SSjo7Lc6EBKB4w5ck#z6MkkkanLE2mcwABMS3RrN4S81E5zo3SSjo7Lc6EBKB4w5ck\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz1ADcQsTdU2YPWsLJ6DWymumr\"],\"proofValue\":\"z5noiPU27dj8gN2W6AJk99whYRWydwbs7wyE8fZZ6KqrZzvQa8iRso66Q25FHtnvTu6zGATMktoJmRXyV4Cyif5fZ\"}}",
+      "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:3c8b5da2-646d-4f0d-93ff-d572e81b4bc9\",\"controller\":\"did:key:z6MkptjaoxjyKQFSqf1dHXswP6EayYhPQBYzprVCPmGBHz9S\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz1ADd8YGQqDFrVDXb85City8t\",\"invocationTarget\":\"https://issuer.qa.veres.app/issuers/z1ADd8YGQqDFrVDXb85City8t/credentials/issue\",\"expires\":\"2024-11-15T17:07:22Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2023-11-16T17:07:22Z\",\"verificationMethod\":\"did:key:z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b#z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz1ADd8YGQqDFrVDXb85City8t\"],\"proofValue\":\"z4bwrLM2ohgGZMvAJMhKMAoPUaEoBdorbKLTFbfLry4pmcz2ei6kTxfRxhpux3tm28SYeiJF1fZcnzHAry5QntYxE\"}}",
       "keySeed": "KEY_SEED_DB"
     },
-    "tags": ["ecdsa-2019", "P-256"]
+    "tags": ["ecdsa-rdfc-2019", "P-256"]
+   }, {
+    "id": "https://issuer.qa.veres.app/issuers/z1AAB8UhLNuAW4TYj6SJbLFos",
+    "endpoint": "https://issuer.qa.veres.app/issuers/z1AAB8UhLNuAW4TYj6SJbLFos/credentials/issue",
+    "method": "POST",
+    "zcap": {
+      "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:b4f664ad-d5f1-4692-8f58-726115ed7273\",\"controller\":\"did:key:z6MkptjaoxjyKQFSqf1dHXswP6EayYhPQBYzprVCPmGBHz9S\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz1AAB8UhLNuAW4TYj6SJbLFos\",\"invocationTarget\":\"https://issuer.qa.veres.app/issuers/z1AAB8UhLNuAW4TYj6SJbLFos/credentials/issue\",\"expires\":\"2024-11-15T17:08:07Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2023-11-16T17:08:08Z\",\"verificationMethod\":\"did:key:z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b#z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz1AAB8UhLNuAW4TYj6SJbLFos\"],\"proofValue\":\"zMfT7RkK978rwgoJJaYe2E6RhSUpi7Eq8cRAwEtQPy9vc96fN3bhwXiGY7bUgpaYV5554z1TUB6st2dH8U669MFb\"}}",
+      "keySeed": "KEY_SEED_DB"
+    },
+    "tags": ["ecdsa-rdfc-2019", "P-384"]
+   }, {
+    "id": "https://issuer.qa.veres.app/issuers/z19thg8b6Bmuo1qSvZBtgU9pu",
+    "endpoint": "https://issuer.qa.veres.app/issuers/z19thg8b6Bmuo1qSvZBtgU9pu/credentials/issue",
+    "method": "POST",
+    "zcap": {
+      "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:95972b0a-1152-4471-b5f2-b6e8c06c6cda\",\"controller\":\"did:key:z6MkptjaoxjyKQFSqf1dHXswP6EayYhPQBYzprVCPmGBHz9S\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz19thg8b6Bmuo1qSvZBtgU9pu\",\"invocationTarget\":\"https://issuer.qa.veres.app/issuers/z19thg8b6Bmuo1qSvZBtgU9pu/credentials/issue\",\"expires\":\"2024-11-15T17:11:48Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2023-11-16T17:11:49Z\",\"verificationMethod\":\"did:key:z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b#z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz19thg8b6Bmuo1qSvZBtgU9pu\"],\"proofValue\":\"z2s1qZduGKEFvZvbLJwjM4da8JFo9NgsPLhUtMHGpDaJcuj7WvUtQPxoF4j9CugnCtW9ywRLt8GQqkDUkc1uLhCEN\"}}",
+      "keySeed": "KEY_SEED_DB"
+    },
+    "tags": ["ecdsa-sd-2023", "P-256"]
    }, {
     "id": "https://vc2.veresissuer.dev/issuers/z1A2ELCrwCJaA8AZKpr3YREye",
     "endpoint": "https://vc2.veresissuer.dev/issuers/z1A2ELCrwCJaA8AZKpr3YREye/credentials/issue",
@@ -54,5 +72,10 @@
       "keySeed": "KEY_SEED_DB"
     },
     "tags": ["vc2.0"]
+  }],
+  "vcHolders": [{
+    "id": "https://vc2.veresverifier.dev/verifiers/z19ojzY8YFhryhpghn6ZaPnHo",
+    "endpoint": "https://vc2.veresverifier.dev/verifiers/z19ojzY8YFhryhpghn6ZaPnHo/presentations/verify",
+    "tags": ["ecdsa-sd-2023", "vcHolder"]
   }]
 }

--- a/implementations/DigitalBazaar.json
+++ b/implementations/DigitalBazaar.json
@@ -67,7 +67,7 @@
       "keySeed": "KEY_SEED_DB"
     },
     "supportedEcdsaKeyTypes": ["P-256", "P-384"],
-    "tags": ["Ed25519Signature2020", "eddsa-rdfc-2022", "ecdsa-rdfc-2019"]
+    "tags": ["Ed25519Signature2020", "eddsa-rdfc-2022", "ecdsa-rdfc-2019", "ecdsa-sd-2023"]
   }, {
     "id": "https://vc2.veresverifier.dev/verifiers/z19ojzY8YFhryhpghn6ZaPnHo",
     "endpoint": "https://vc2.veresverifier.dev/verifiers/z19ojzY8YFhryhpghn6ZaPnHo/credentials/verify",

--- a/implementations/DigitalBazaar.json
+++ b/implementations/DigitalBazaar.json
@@ -1,6 +1,6 @@
 {
   "name": "Digital Bazaar",
-  "implementation": "Veres One (Q/A)",
+  "implementation": "Veres (Q/A)",
   "issuers": [{
     "id": "https://issuer.qa.veres.app/issuers/z1AEwLo7tZ3TrsPgRcgLJqQvR",
     "endpoint": "https://issuer.qa.veres.app/issuers/z1AEwLo7tZ3TrsPgRcgLJqQvR/credentials/issue",

--- a/implementations/DigitalBazaar.json
+++ b/implementations/DigitalBazaar.json
@@ -2,8 +2,8 @@
   "name": "Digital Bazaar",
   "implementation": "Veres One (Q/A)",
   "issuers": [{
-    "id": "https://issuer.qa.veres.app/issuers/z19rYvMxCQzMb9hQ7xuQ5ipJd",
-    "endpoint": "https://issuer.qa.veres.app/issuers/z19rYvMxCQzMb9hQ7xuQ5ipJd/credentials/issue",
+    "id": "https://issuer.qa.veres.app/issuers/z1AEwLo7tZ3TrsPgRcgLJqQvR",
+    "endpoint": "https://issuer.qa.veres.app/issuers/z1AEwLo7tZ3TrsPgRcgLJqQvR/credentials/issue",
     "method": "POST",
     "zcap": {
       "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:2432d7c1-8082-410d-b9fb-0c40ae0dbce4\",\"controller\":\"did:key:z6MkptjaoxjyKQFSqf1dHXswP6EayYhPQBYzprVCPmGBHz9S\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz1AEwLo7tZ3TrsPgRcgLJqQvR\",\"invocationTarget\":\"https://issuer.qa.veres.app/issuers/z1AEwLo7tZ3TrsPgRcgLJqQvR/credentials/issue\",\"expires\":\"2024-11-15T19:06:05Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2023-11-16T19:06:06Z\",\"verificationMethod\":\"did:key:z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b#z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz1AEwLo7tZ3TrsPgRcgLJqQvR\"],\"proofValue\":\"z2x1TjQQHHS82K76CV9JzTom42CHhDhq2ShiPvqfCJWqvq2iQuveFW8mik9f4XytctzQDQpiYsuDx3Y27dxKJbbbd\"}}",

--- a/implementations/DigitalBazaar.json
+++ b/implementations/DigitalBazaar.json
@@ -48,13 +48,13 @@
     "tags": ["vc2.0"]
    }],
    "verifiers": [{
-    "id": "https://verifier.qa.veres.app/verifiers/z19yAyX2nGTNjpron7m9PYp3T",
-    "endpoint": "https://verifier.qa.veres.app/verifiers/z19yAyX2nGTNjpron7m9PYp3T/credentials/verify",
+    "id": "https://verifier.qa.veres.app/verifiers/z19jXQPi819fJVaBRFxZXqXay",
+    "endpoint": "https://verifier.qa.veres.app/verifiers/z19jXQPi819fJVaBRFxZXqXay/credentials/verify",
     "zcap": {
-      "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:672ede0e-1e66-4b26-a36c-8c96ec7593f6\",\"controller\":\"did:key:z6MkptjaoxjyKQFSqf1dHXswP6EayYhPQBYzprVCPmGBHz9S\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fverifier.qa.veres.app%2Fverifiers%2Fz19yAyX2nGTNjpron7m9PYp3T\",\"invocationTarget\":\"https://verifier.qa.veres.app/verifiers/z19yAyX2nGTNjpron7m9PYp3T/credentials\",\"expires\":\"2024-06-25T20:29:46Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2023-06-26T20:29:47Z\",\"verificationMethod\":\"did:key:z6MkkkanLE2mcwABMS3RrN4S81E5zo3SSjo7Lc6EBKB4w5ck#z6MkkkanLE2mcwABMS3RrN4S81E5zo3SSjo7Lc6EBKB4w5ck\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fverifier.qa.veres.app%2Fverifiers%2Fz19yAyX2nGTNjpron7m9PYp3T\"],\"proofValue\":\"z2oBzpifvAxZVQpR3h84EDTt83pxp8swfrvowCR1EDg35HuqcfNKBSGh8EpS2cPo7zFAmEPqy6cSLEZEjYdjbeo9Y\"}}",
+      "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:73c6ab6d-fd9d-48d8-8260-c0839555e824\",\"controller\":\"did:key:z6MkptjaoxjyKQFSqf1dHXswP6EayYhPQBYzprVCPmGBHz9S\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fverifier.qa.veres.app%2Fverifiers%2Fz19jXQPi819fJVaBRFxZXqXay\",\"invocationTarget\":\"https://verifier.qa.veres.app/verifiers/z19jXQPi819fJVaBRFxZXqXay/credentials/verify\",\"expires\":\"2024-11-15T17:57:43Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2023-11-16T17:57:44Z\",\"verificationMethod\":\"did:key:z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b#z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fverifier.qa.veres.app%2Fverifiers%2Fz19jXQPi819fJVaBRFxZXqXay\"],\"proofValue\":\"z2Jcv3ZMfKX4FgXwnK7g4ix8WpWxhtiPdFdL1qjw7Y8XsNrEbeK5CosBPcZwLm9SrCafahF4tkufUmg5QtX51kE11\"}}",
       "keySeed": "KEY_SEED_DB"
     },
-    "tags": ["Ed25519Signature2020", "eddsa-2022", "ecdsa-2019"]
+    "tags": ["Ed25519Signature2020", "eddsa-rdfc-2022", "ecdsa-rdfc-2019"]
   }, {
     "id": "https://vc2.veresverifier.dev/verifiers/z19ojzY8YFhryhpghn6ZaPnHo",
     "endpoint": "https://vc2.veresverifier.dev/verifiers/z19ojzY8YFhryhpghn6ZaPnHo/credentials/verify",

--- a/implementations/DigitalBazaar.json
+++ b/implementations/DigitalBazaar.json
@@ -6,6 +6,15 @@
     "endpoint": "https://issuer.qa.veres.app/issuers/z19rYvMxCQzMb9hQ7xuQ5ipJd/credentials/issue",
     "method": "POST",
     "zcap": {
+      "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:2432d7c1-8082-410d-b9fb-0c40ae0dbce4\",\"controller\":\"did:key:z6MkptjaoxjyKQFSqf1dHXswP6EayYhPQBYzprVCPmGBHz9S\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz1AEwLo7tZ3TrsPgRcgLJqQvR\",\"invocationTarget\":\"https://issuer.qa.veres.app/issuers/z1AEwLo7tZ3TrsPgRcgLJqQvR/credentials/issue\",\"expires\":\"2024-11-15T19:06:05Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2023-11-16T19:06:06Z\",\"verificationMethod\":\"did:key:z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b#z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz1AEwLo7tZ3TrsPgRcgLJqQvR\"],\"proofValue\":\"z2x1TjQQHHS82K76CV9JzTom42CHhDhq2ShiPvqfCJWqvq2iQuveFW8mik9f4XytctzQDQpiYsuDx3Y27dxKJbbbd\"}}",
+      "keySeed": "KEY_SEED_DB"
+    },
+    "tags": ["Ed25519Signature2020"]
+   }, {
+    "id": "https://issuer.qa.veres.app/issuers/z19rYvMxCQzMb9hQ7xuQ5ipJd",
+    "endpoint": "https://issuer.qa.veres.app/issuers/z19rYvMxCQzMb9hQ7xuQ5ipJd/credentials/issue",
+    "method": "POST",
+    "zcap": {
       "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:10765250-c445-4672-8271-16a033d5fc51\",\"controller\":\"did:key:z6MkptjaoxjyKQFSqf1dHXswP6EayYhPQBYzprVCPmGBHz9S\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz19rYvMxCQzMb9hQ7xuQ5ipJd\",\"invocationTarget\":\"https://issuer.qa.veres.app/issuers/z19rYvMxCQzMb9hQ7xuQ5ipJd/credentials/issue\",\"expires\":\"2024-11-15T17:06:07Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2023-11-16T17:06:08Z\",\"verificationMethod\":\"did:key:z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b#z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz19rYvMxCQzMb9hQ7xuQ5ipJd\"],\"proofValue\":\"z55MhL1RCGvM1oLd9KqRwSP8rQu5wkr5tcyJbgi4CHvvvvhH65TxVATbHqLQT7b1zPZa7nbVCrUwSxwihoVCjrivU\"}}",
       "keySeed": "KEY_SEED_DB"
     },

--- a/implementations/DigitalBazaar.json
+++ b/implementations/DigitalBazaar.json
@@ -87,8 +87,8 @@
     "tags": ["vc2.0"]
   }],
   "vcHolders": [{
-    "id": "https://vc2.veresverifier.dev/verifiers/z19ojzY8YFhryhpghn6ZaPnHo",
-    "endpoint": "https://vc2.veresverifier.dev/verifiers/z19ojzY8YFhryhpghn6ZaPnHo/presentations/verify",
-    "tags": ["ecdsa-sd-2023", "vcHolder"]
+    "id": "https://vcholder.vcplayground.org",
+    "endpoint": "https://vcholder.vcplayground.org/derive",
+    "tags": ["vcHolder"]
   }]
 }

--- a/implementations/DigitalBazaar.json
+++ b/implementations/DigitalBazaar.json
@@ -27,7 +27,8 @@
       "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:3c8b5da2-646d-4f0d-93ff-d572e81b4bc9\",\"controller\":\"did:key:z6MkptjaoxjyKQFSqf1dHXswP6EayYhPQBYzprVCPmGBHz9S\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz1ADd8YGQqDFrVDXb85City8t\",\"invocationTarget\":\"https://issuer.qa.veres.app/issuers/z1ADd8YGQqDFrVDXb85City8t/credentials/issue\",\"expires\":\"2024-11-15T17:07:22Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2023-11-16T17:07:22Z\",\"verificationMethod\":\"did:key:z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b#z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz1ADd8YGQqDFrVDXb85City8t\"],\"proofValue\":\"z4bwrLM2ohgGZMvAJMhKMAoPUaEoBdorbKLTFbfLry4pmcz2ei6kTxfRxhpux3tm28SYeiJF1fZcnzHAry5QntYxE\"}}",
       "keySeed": "KEY_SEED_DB"
     },
-    "tags": ["ecdsa-rdfc-2019", "P-256"]
+    "supportedEcdsaKeyTypes": ["P-256"],
+    "tags": ["ecdsa-rdfc-2019"]
    }, {
     "id": "https://issuer.qa.veres.app/issuers/z1AAB8UhLNuAW4TYj6SJbLFos",
     "endpoint": "https://issuer.qa.veres.app/issuers/z1AAB8UhLNuAW4TYj6SJbLFos/credentials/issue",
@@ -36,7 +37,8 @@
       "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:b4f664ad-d5f1-4692-8f58-726115ed7273\",\"controller\":\"did:key:z6MkptjaoxjyKQFSqf1dHXswP6EayYhPQBYzprVCPmGBHz9S\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz1AAB8UhLNuAW4TYj6SJbLFos\",\"invocationTarget\":\"https://issuer.qa.veres.app/issuers/z1AAB8UhLNuAW4TYj6SJbLFos/credentials/issue\",\"expires\":\"2024-11-15T17:08:07Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2023-11-16T17:08:08Z\",\"verificationMethod\":\"did:key:z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b#z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz1AAB8UhLNuAW4TYj6SJbLFos\"],\"proofValue\":\"zMfT7RkK978rwgoJJaYe2E6RhSUpi7Eq8cRAwEtQPy9vc96fN3bhwXiGY7bUgpaYV5554z1TUB6st2dH8U669MFb\"}}",
       "keySeed": "KEY_SEED_DB"
     },
-    "tags": ["ecdsa-rdfc-2019", "P-384"]
+    "supportedEcdsaKeyTypes": ["P-384"],
+    "tags": ["ecdsa-rdfc-2019"]
    }, {
     "id": "https://issuer.qa.veres.app/issuers/z19thg8b6Bmuo1qSvZBtgU9pu",
     "endpoint": "https://issuer.qa.veres.app/issuers/z19thg8b6Bmuo1qSvZBtgU9pu/credentials/issue",
@@ -45,7 +47,8 @@
       "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:95972b0a-1152-4471-b5f2-b6e8c06c6cda\",\"controller\":\"did:key:z6MkptjaoxjyKQFSqf1dHXswP6EayYhPQBYzprVCPmGBHz9S\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz19thg8b6Bmuo1qSvZBtgU9pu\",\"invocationTarget\":\"https://issuer.qa.veres.app/issuers/z19thg8b6Bmuo1qSvZBtgU9pu/credentials/issue\",\"expires\":\"2024-11-15T17:11:48Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2023-11-16T17:11:49Z\",\"verificationMethod\":\"did:key:z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b#z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz19thg8b6Bmuo1qSvZBtgU9pu\"],\"proofValue\":\"z2s1qZduGKEFvZvbLJwjM4da8JFo9NgsPLhUtMHGpDaJcuj7WvUtQPxoF4j9CugnCtW9ywRLt8GQqkDUkc1uLhCEN\"}}",
       "keySeed": "KEY_SEED_DB"
     },
-    "tags": ["ecdsa-sd-2023", "P-256"]
+    "supportedEcdsaKeyTypes": ["P-256"],
+    "tags": ["ecdsa-sd-2023"]
    }, {
     "id": "https://vc2.veresissuer.dev/issuers/z1A2ELCrwCJaA8AZKpr3YREye",
     "endpoint": "https://vc2.veresissuer.dev/issuers/z1A2ELCrwCJaA8AZKpr3YREye/credentials/issue",
@@ -63,6 +66,7 @@
       "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:73c6ab6d-fd9d-48d8-8260-c0839555e824\",\"controller\":\"did:key:z6MkptjaoxjyKQFSqf1dHXswP6EayYhPQBYzprVCPmGBHz9S\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fverifier.qa.veres.app%2Fverifiers%2Fz19jXQPi819fJVaBRFxZXqXay\",\"invocationTarget\":\"https://verifier.qa.veres.app/verifiers/z19jXQPi819fJVaBRFxZXqXay/credentials/verify\",\"expires\":\"2024-11-15T17:57:43Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2023-11-16T17:57:44Z\",\"verificationMethod\":\"did:key:z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b#z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fverifier.qa.veres.app%2Fverifiers%2Fz19jXQPi819fJVaBRFxZXqXay\"],\"proofValue\":\"z2Jcv3ZMfKX4FgXwnK7g4ix8WpWxhtiPdFdL1qjw7Y8XsNrEbeK5CosBPcZwLm9SrCafahF4tkufUmg5QtX51kE11\"}}",
       "keySeed": "KEY_SEED_DB"
     },
+    "supportedEcdsaKeyTypes": ["P-256", "P-384"],
     "tags": ["Ed25519Signature2020", "eddsa-rdfc-2022", "ecdsa-rdfc-2019"]
   }, {
     "id": "https://vc2.veresverifier.dev/verifiers/z19ojzY8YFhryhpghn6ZaPnHo",

--- a/implementations/SpruceID.json
+++ b/implementations/SpruceID.json
@@ -21,11 +21,13 @@
     "options": {
       "type": "DataIntegrityProof"
     },
-    "tags": ["ecdsa-rdfc-2019", "P-256"]
+    "supportedEcdsaKeyTypes": ["P-256"],
+    "tags": ["ecdsa-rdfc-2019"]
   }],
   "verifiers": [{
     "id": "https://spruceid.com",
     "endpoint": "https://vc.spruceid.xyz/credentials/verify",
+    "supportedEcdsaKeyTypes": ["P-256"],
     "tags": ["Ed25519Signature2020", "eddsa-rdfc-2022", "ecdsa-rdfc-2019"]
   }]
 }

--- a/implementations/SpruceID.json
+++ b/implementations/SpruceID.json
@@ -14,18 +14,18 @@
     "options": {
       "type": "DataIntegrityProof"
     },
-    "tags": ["eddsa-2022"]
+    "tags": ["eddsa-rdfc-2022"]
   }, {
     "id": "did:key:zDnaei6w9La4VphyPA6V2V5poBTpVtjCsnzPML5c78GWjRhnc",
     "endpoint": "https://vc.spruceid.xyz/credentials/issue",
     "options": {
       "type": "DataIntegrityProof"
     },
-    "tags": ["ecdsa-2019"]
+    "tags": ["ecdsa-rdfc-2019"]
   }],
   "verifiers": [{
     "id": "https://spruceid.com",
     "endpoint": "https://vc.spruceid.xyz/credentials/verify",
-    "tags": ["Ed25519Signature2020", "eddsa-2022", "ecdsa-2019"]
+    "tags": ["Ed25519Signature2020", "eddsa-rdfc-2022", "ecdsa-rdfc-2019"]
   }]
 }

--- a/implementations/SpruceID.json
+++ b/implementations/SpruceID.json
@@ -21,7 +21,7 @@
     "options": {
       "type": "DataIntegrityProof"
     },
-    "tags": ["ecdsa-rdfc-2019"]
+    "tags": ["ecdsa-rdfc-2019", "P-256"]
   }],
   "verifiers": [{
     "id": "https://spruceid.com",

--- a/implementations/Trinsic.json
+++ b/implementations/Trinsic.json
@@ -14,11 +14,11 @@
     "options": {
       "type": "DataIntegrityProof"
     },
-    "tags": ["vc-api", "eddsa-2022"]
+    "tags": ["vc-api", "eddsa-rdfc-2022"]
   }],
   "verifiers": [{
     "id": "https://trinsic.id",
     "endpoint": "https://interop.connect.trinsic.cloud/vc-api/credentials/verify",
-    "tags": ["vc-api", "eddsa-2022", "Ed25519Signature2020"]
+    "tags": ["vc-api", "eddsa-rdfc-2022", "Ed25519Signature2020"]
   }]
 }


### PR DESCRIPTION
- Add `supportedEcdsaKeyTypes` property to ` ecdsa-rdfc-2019` issuer and verifier implementations
- Update DB implementations.

Related PRs:

https://github.com/w3c/vc-di-eddsa-test-suite/pull/24
https://github.com/w3c/vc-di-ecdsa-test-suite/pull/19