### PR TITLE
Remove `vc-api` tag.

### DIFF
--- a/implementations/Trinsic.json
+++ b/implementations/Trinsic.json
@@ -7,18 +7,18 @@
     "options": {
       "type": "Ed25519Signature2020"
     },
-    "tags": ["vc-api", "Ed25519Signature2020"]
+    "tags": ["Ed25519Signature2020"]
   }, {
     "id": "did:key:z6MkqbpLSbqnY1pxVyhBCDYcFsv4ZgGgqP32kzNrf5deWVPU",
     "endpoint": "https://interop.connect.trinsic.cloud/vc-api/credentials/issue",
     "options": {
       "type": "DataIntegrityProof"
     },
-    "tags": ["vc-api", "eddsa-rdfc-2022"]
+    "tags": ["eddsa-rdfc-2022"]
   }],
   "verifiers": [{
     "id": "https://trinsic.id",
     "endpoint": "https://interop.connect.trinsic.cloud/vc-api/credentials/verify",
-    "tags": ["vc-api", "eddsa-rdfc-2022", "Ed25519Signature2020"]
+    "tags": ["eddsa-rdfc-2022", "Ed25519Signature2020"]
   }]
 }


### PR DESCRIPTION
The tag is meant for running implementations against the VC API issuer and verifier tests, while the implementations here are  run with other test suites(ecdsa, eddsa, Ed255192020Signature and vc-2.0).