### PR TITLE
Only run local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+<!--
+Copyright 2023 Digital Bazaar, Inc.
+
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
+# w3c/vc-test-suite-implementations  ChangeLog
+
+## 1.0.0 -
+
+### Added
+- A new option `only` which when added to an implementation manifest results in only that manifest being run.
+- Support for `localImplementationsConfig.cjs` a non-dot file config file.
+
+## Before 1.0.0
+
+- See git history for changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 ### Added
 - A new option `only` which when added to an implementation manifest results in only that manifest being run.
-- Support for `localImplementationsConfig.cjs` a non-dot file config file.
+- Support for `localImplementationsConfig.cjs` a non-dot file config file in addition to the existing dot file.
 
 ## Before 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: BSD-3-Clause
 ## 1.0.0 -
 
 ### Added
-- A new option `only` which when added to an implementation manifest results in only that manifest being run.
+- A new option `only` which when added to a local implementation manifest results in only that manifest being run.
 - Support for `localImplementationsConfig.cjs` a non-dot file config file in addition to the existing dot file.
 
 ## Before 1.0.0

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ non-localhost implementations will be included in the test run. To just run impl
 from the local config file see the [Using only](#using-only) section below.
 
 ### Using only
-Implementations marked `only` will exclude implementations not marked `only`.
-To only run a local implementation in the suite set `only: true` in
+Implementations marked `only` will be the only implementations used in a test run.
+For example, to only run local implementations in a suite set `only: true` in
 the local implementation manifest.
 
 ```js
@@ -151,8 +151,6 @@ module.exports = [{
   }]
 }];
 ```
-To run against select implementations simply copy the other manifests to a
-local manifest and then set `only: true` in the implementations for that test run.
 
 ### Tags
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ be regularly run against the
   - [Usage](#usage)
     - [Adding a new implementation](#adding-a-new-implementation)
     - [Testing locally](#testing-locally)
+    - [Using only](#using-only)
     - [Tags](#tags)
   - [Contribute](#contribute)
   - [License](#license)
@@ -99,8 +100,8 @@ parameters, in which case they do not specify `oauth2` or `zcap` properties.
 
 #### Testing locally
 
-If you want to test your implementations for endpoints running locally, you can
-create a configuration file `.localImplementationsConfig.cjs` in the root
+To test implementations with endpoints running locally, create a configuration file named
+either `.localImplementationsConfig.cjs` or `localImplementationsConfig.cjs` in the root
 directory of the test suite.
 
 This file must be a CommonJS module that exports an array of implementations:
@@ -124,16 +125,34 @@ module.exports = [{
 ```
 
 After adding the config file, both the localhost implementations and other
-non-localhost implementations will be included in the test run.
+non-localhost implementations will be included in the test run. To just run implementations
+from the local config file see the [Using only](#using-only) section below.
 
-To specifically test only the localhost implementation, modify the test suite to
-filter implementations based on a specific tag in your configuration file.
+### Using only
+Implementations marked `only` will exclude implementations not marked `only`.
+To only run a local implementation in the suite set `only: true` in
+the local implementation manifest.
 
-For instance, if your `.localImplementationsConfig.cjs` config file looks like
-above in the `di-eddsa-2022-test-suite`, you can adjust the tag used in each test
-file of the test suite (for example -
-https://github.com/w3c/vc-di-eddsa-test-suite/blob/main/tests/10-rdfc-create.js#L16)
-to filter the implementations by `localhost` instead of `eddsa-rdfc-2022`.
+```js
+module.exports = [{
+  "name": "My Company",
+  "implementation": "My Implementation Name",
+  // this will ensure only this implementation is used in a suite
+  "only": true,
+  "issuers": [{
+    "id": "urn:uuid:my:implementation:issuer:id",
+    "endpoint": "https://localhost:40443/issuers/foo/credentials/issue",
+    "tags": ["eddsa-rdfc-2022", "localhost"]
+  }],
+  "verifiers": [{
+    "id": "https://localhost:40443/verifiers/z19uokPn3b1Z4XDbQSHo7VhFR",
+    "endpoint": "https://localhost:40443/verifiers/z19uokPn3b1Z4XDbQSHo7VhFR/credentials/verify",
+    "tags": ["eddsa-rdfc-2022", "localhost"]
+  }]
+}];
+```
+To run against select implementations simply copy the other manifests to a
+local manifest and then set `only: true` in the implementations for that test run.
 
 ### Tags
 

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ non-localhost implementations will be included in the test run. To just run impl
 from the local config file see the [Using only](#using-only) section below.
 
 ### Using only
-Implementations marked `only` will be the only implementations used in a test run.
-For example, to only run local implementations in a suite set `only: true` in
+Local Implementations marked `only` will be the only implementations used in a test run.
+For example, to only run a single implementation in a suite set `only: true` in
 the local implementation manifest.
 
 ```js

--- a/implementations/index.js
+++ b/implementations/index.js
@@ -7,12 +7,12 @@ import {join} from 'node:path';
 
 const require = createRequire(import.meta.url);
 const requireDir = require('require-dir');
+const manifests = {};
+// get all the remote implementations in this dir
+manifests.remote = Object.values(requireDir('./'));
 
-// get all the json files in this dir
-const manifests = Object.values(requireDir('./'));
-
-// gets local implementations from an optional config file
-const getLocalImplementations = fileName => {
+// gets local manifests from an optional config file
+const getLocalManifest = fileName => {
   try {
     const path = join(
       appRoot.toString(), fileName);
@@ -25,18 +25,16 @@ const getLocalImplementations = fileName => {
   }
 };
 
-// open either list of local endpoints and merge into one list of endpoints.
-const localImplementations = [
-  getLocalImplementations('.localImplementationsConfig.cjs'),
-  getLocalImplementations('localImplementationsConfig.cjs')
-].flatMap(a => a);
+// get all local endpoints dot file or otherwise
+manifests.local = [
+  '.localImplementationsConfig.cjs',
+  'localImplementationsConfig.cjs'
+].flatMap(path => getLocalManifest(path));
 
-// concat all the manifests together
-const allManifests = manifests.concat(localImplementations);
+// concat all the implementation manifests together
+const all = manifests.all = manifests.remote.concat(manifests.local);
 
 // look for only in a manifest
-const hasOnly = allManifests.filter(i => i?.only === true);
+const only = manifests.only = manifests.all.filter(i => i?.only === true);
 
-// if any manifest has only true only return the hasOnly
-// otherwise return all the manifests
-export const implementerFiles = hasOnly.length ? hasOnly : allManifests;
+export const implementerFiles = only.length ? only : all;

--- a/implementations/index.js
+++ b/implementations/index.js
@@ -31,8 +31,12 @@ const localImplementations = [
   getLocalImplementations('localImplementationsConfig.cjs')
 ].flatMap(a => a);
 
-// look for local only in a local settings file
-const localOnly = localImplementations.some(i => i?.local === true);
+// concat all the manifests together
+const allManifests = manifests.concat(localImplementations);
 
-export const implementerFiles = localOnly ? localImplementations :
-  manifests.concat(localImplementations);
+// look for only in a manifest
+const hasOnly = allManifests.filter(i => i?.only === true);
+
+// if any manifest has only true only return the hasOnly
+// otherwise return all the manifests
+export const implementerFiles = hasOnly.length ? hasOnly : allManifests;

--- a/implementations/index.js
+++ b/implementations/index.js
@@ -34,7 +34,7 @@ manifests.local = [
 // concat all the implementation manifests together
 const all = manifests.all = manifests.remote.concat(manifests.local);
 
-// look for only in a manifest
-const only = manifests.only = manifests.all.filter(i => i?.only === true);
+// look for only in a local manifests
+const only = manifests.only = manifests.local.filter(i => i?.only === true);
 
 export const implementerFiles = only.length ? only : all;


### PR DESCRIPTION
Adds 2 new features:

1. a new property `only` that can be attached to an implementation so only specific implementations run in a suite
2. support for non-dot file `localImplementationsConfig.cjs` files
3. Adds a CHANGELOG


This PR makes this PR possible: https://github.com/w3c/vc-di-ecdsa-test-suite/pull/47

Discussion:
1. Should we only allow / check local implementations for `only: true`?