### PR TITLE
Fix incorrect issuer IDs for GrottoNetworking.

### DIFF
--- a/implementations/GrottoNetworking.json
+++ b/implementations/GrottoNetworking.json
@@ -2,13 +2,13 @@
     "name": "Grotto Networking",
     "implementation": "Grotto Selective Disclosure Libraries",
     "issuers": [{
-      "id": "did:key:zDnaepBuvsQ8cpsWrVKw8fbpGpvPeNSjVPTWoq6cRqaYzBKVP#zDnaepBuvsQ8cpsWrVKw8fbpGpvPeNSjVPTWoq6cRqaYzBKVP",
+      "id": "did:key:zDnaepBuvsQ8cpsWrVKw8fbpGpvPeNSjVPTWoq6cRqaYzBKVP",
       "endpoint": "https://ecdsa-sd.grotto-networking.com/credentials/issue",
       "tags": ["ecdsa-sd-2023"],
       "supportedEcdsaKeyTypes": ["P-256"]
     },
     {
-      "id": "did:key:zUC7DerdEmfZ8f4pFajXgGwJoMkV1ofMTmEG5UoNvnWiPiLuGKNeqgRpLH2TV4Xe5mJ2cXV76gRN7LFQwapF1VFu6x2yrr5ci1mXqC1WNUrnHnLgvfZfMH7h6xP6qsf9EKRQrPQ#zUC7DerdEmfZ8f4pFajXgGwJoMkV1ofMTmEG5UoNvnWiPiLuGKNeqgRpLH2TV4Xe5mJ2cXV76gRN7LFQwapF1VFu6x2yrr5ci1mXqC1WNUrnHnLgvfZfMH7h6xP6qsf9EKRQrPQ",
+      "id": "did:key:zUC7DerdEmfZ8f4pFajXgGwJoMkV1ofMTmEG5UoNvnWiPiLuGKNeqgRpLH2TV4Xe5mJ2cXV76gRN7LFQwapF1VFu6x2yrr5ci1mXqC1WNUrnHnLgvfZfMH7h6xP6qsf9EKRQrPQ",
       "endpoint": "https://ecdsa-sd.grotto-networking.com/BBS/credentials/issue",
       "tags": ["bbs-2023"]
     }],

--- a/test/implementations.spec.js
+++ b/test/implementations.spec.js
@@ -13,4 +13,33 @@ describe('Loading implementations', () => {
   it('result in no errors.', async () => {
     should.exist(allImplementations);
   });
+
+  describe('Implementations using DID:key identifiers', () => {
+    allImplementations.forEach(implementation => {
+      const {issuers, verifiers} = implementation;
+
+      const isDidKeyFilter = ({settings: {id}}) =>
+        id && id.startsWith('did:key');
+
+      describe(implementation.settings.name, () => {
+        issuers.filter(isDidKeyFilter)
+          .map(({settings: {id}}, index) => {
+            describe(`issuer[${index}].id`, () => {
+              it('should not specify a fragment', () => {
+                chai.expect(id).not.match(/#/);
+              });
+            });
+          });
+
+        verifiers.filter(isDidKeyFilter)
+          .map(({settings: {id}}, index) => {
+            describe(`verifier[${index}].id`, () => {
+              it('should not specify a fragment', () => {
+                chai.expect(id).not.match(/#/);
+              });
+            });
+          });
+      });
+    });
+  });
 });


### PR DESCRIPTION
One implementation was using an incorrect issuer ID DID:key.

This PR corrects the issue and adds a local test to ensure all issuers using DID:key ids are correct going forward.