### PR TITLE
Overwrite default with localConfig.settings.

### DIFF
--- a/implementations/index.js
+++ b/implementations/index.js
@@ -29,9 +29,9 @@ const getLocalManifest = fileName => {
 
 const localConfig = getLocalManifest('localConfig.cjs');
 export const localSettings = (Object.keys(localConfig).length > 0) ?
-  // we have a localConfig object, so merge in local defaults
-  {...localConfig?.settings,
-    ...{enableInteropTests: false, testAllImplementations: false}} :
+  // if there is a localConfig.settings overwrite local defaults
+  {...{enableInteropTests: false, testAllImplementations: false},
+    ...localConfig?.settings} :
   // otherwise, return the global defaults
   // FIXME: ...consider renaming `localSettings` as it can hold global ones...
   {enableInteropTests: true, testAllImplementations: true};


### PR DESCRIPTION
So I believe this fixes the `localConfig.settings` to work the way intended.

What is mostly does is this: when using the javascript object spread syntax, the first object is overwritten by the next spread object. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax

```js
> const a = {foo: true}
> const b = {foo: false}
// b is last so it's values will take precedence
> const aB = {...a, ...b}
> aB
{ foo: false }
// a is last so it's values will take precedence
> const bA = {...b, ...a}
> bA
{ foo: true }
```

So basically this PR means that the value of `localConfig.settings` overwrites the first set of defaults.
This means that `settings.enableInteropTests` and `settings.testAllImplementations` from a test suite's localConfig will overwrite the defaults enabling you to run your local implementations against remote implementations and interop tests and stuff like that.