### PR TITLE
Replace eddsa-rdfc-2022 endpoint with VC 2.0 version.

### DIFF
--- a/implementations/DigitalBazaar.json
+++ b/implementations/DigitalBazaar.json
@@ -10,13 +10,16 @@
     },
     "tags": ["Ed25519Signature2020"]
    }, {
-    "id": "https://issuer.qa.veres.app/issuers/z19rYvMxCQzMb9hQ7xuQ5ipJd",
-    "endpoint": "https://issuer.qa.veres.app/issuers/z19rYvMxCQzMb9hQ7xuQ5ipJd/credentials/issue",
-    "zcap": {
-      "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:10765250-c445-4672-8271-16a033d5fc51\",\"controller\":\"did:key:z6MkptjaoxjyKQFSqf1dHXswP6EayYhPQBYzprVCPmGBHz9S\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz19rYvMxCQzMb9hQ7xuQ5ipJd\",\"invocationTarget\":\"https://issuer.qa.veres.app/issuers/z19rYvMxCQzMb9hQ7xuQ5ipJd/credentials/issue\",\"expires\":\"2024-11-15T17:06:07Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2023-11-16T17:06:08Z\",\"verificationMethod\":\"did:key:z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b#z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fissuer.qa.veres.app%2Fissuers%2Fz19rYvMxCQzMb9hQ7xuQ5ipJd\"],\"proofValue\":\"z55MhL1RCGvM1oLd9KqRwSP8rQu5wkr5tcyJbgi4CHvvvvhH65TxVATbHqLQT7b1zPZa7nbVCrUwSxwihoVCjrivU\"}}",
-      "keySeed": "KEY_SEED_DB"
-    },
-    "tags": ["eddsa-rdfc-2022"]
+      "id": "did:key:z6MkmfwYETCWBFzrab4Z5yPauJ2yxk7iw6iykTdHtixsi6p7",
+      "endpoint": "https://vc2.veresissuer.dev/issuers/z1ABPdeQDvAnbdPuWEwJsFsbW/credentials/issue",
+      "zcap": {
+        "capability": "{\"@context\":[\"https://w3id.org/zcap/v1\",\"https://w3id.org/security/suites/ed25519-2020/v1\"],\"id\":\"urn:uuid:75ec2ee0-047e-443c-a3b5-eb0d618d10d6\",\"controller\":\"did:key:z6MkptjaoxjyKQFSqf1dHXswP6EayYhPQBYzprVCPmGBHz9S\",\"parentCapability\":\"urn:zcap:root:https%3A%2F%2Fvc2.veresissuer.dev%2Fissuers%2Fz1ABPdeQDvAnbdPuWEwJsFsbW\",\"invocationTarget\":\"https://vc2.veresissuer.dev/issuers/z1ABPdeQDvAnbdPuWEwJsFsbW/credentials/issue\",\"expires\":\"2025-05-31T13:45:24Z\",\"proof\":{\"type\":\"Ed25519Signature2020\",\"created\":\"2024-05-31T13:45:25Z\",\"verificationMethod\":\"did:key:z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b#z6MkmMeWhZTJr8mhA2n48FoKV1kLqJAm9eYdu4cdTtTC6Y5b\",\"proofPurpose\":\"capabilityDelegation\",\"capabilityChain\":[\"urn:zcap:root:https%3A%2F%2Fvc2.veresissuer.dev%2Fissuers%2Fz1ABPdeQDvAnbdPuWEwJsFsbW\"],\"proofValue\":\"z2aECBtpfUd8Y79J7P3Do8gKeHuSkH5z5joimC2apCfvdK5SYAt8bX7BqRFSi9PJmN9cZYmGKCXvgJSPM83Jmiuuk\"}}",
+        "keySeed": "KEY_SEED_DB"
+      },
+      "supports": {
+        "vc": ["1.1", "2.0"]
+      },
+      "tags": ["eddsa-rdfc-2022"]
    }, {
     "id": "did:key:zDnaexu7dNiESVoqicP5bbbV2cPVMRhByztVFHKZ16tD1okXZ",
     "endpoint": "https://vc2.veresissuer.dev/issuers/z19sAcw65hVQKj6Xk6HsY6Eas/credentials/issue",


### PR DESCRIPTION
replaces id with a `did:key` and uses a VC 2.0 endpoint for the tests

Before replacement 95% conformance for DB after replacement 95% conformance for DB.