### PR TITLE
PATCH: Export localSettings.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -10,6 +10,7 @@ import {implementerFiles} from '../implementations/index.js';
 const keyValues = implementerFiles.map(
   implementation => [implementation.name, new Implementation(implementation)]);
 
+export {localSettings} from '../implementations/index.js';
 export const implementations = new Map(keyValues);
 export const allImplementations = implementations;
 


### PR DESCRIPTION
localSettings is used in both ecdsa and bbs test suites.
It is also pretty useful and in the future might be used for more options.