### PR TITLE
Shorten Open Security and Identity implementation name

### DIFF
--- a/implementations/OpSecId.json
+++ b/implementations/OpSecId.json
@@ -1,5 +1,5 @@
 {
-  "name": "Open Security and Identity",
+  "name": "OpSecId",
   "implementation": "Aca-py VC-API Plugin",
   "verifiers": [
     {


### PR DESCRIPTION
Current name takes up useless space in the reports because of column width. Replacing the full name with an alias for better user readability.