### PR TITLE
Switch from shouty case to lowercase for header sanitization.

### DIFF
--- a/lib/requests.js
+++ b/lib/requests.js
@@ -174,7 +174,7 @@ function _sanitizeHeaders({httpMessage, headers = sanitizeHeaders}) {
   for(const header of headers) {
     // sanitize the headers to prevent
     // authn tokens / information potentially in logs
-    newHeaders.set(header, 'sanitized');
+    newHeaders.set(header, 'sanitized to prevent exposure of secrets');
   }
   return newHeaders;
 }

--- a/lib/requests.js
+++ b/lib/requests.js
@@ -174,7 +174,7 @@ function _sanitizeHeaders({httpMessage, headers = sanitizeHeaders}) {
   for(const header of headers) {
     // sanitize the headers to prevent
     // authn tokens / information potentially in logs
-    newHeaders.set(header, '** SANITIZED TO PREVENT EXPOSING OF SECRETS ***');
+    newHeaders.set(header, 'sanitized');
   }
   return newHeaders;
 }


### PR DESCRIPTION
Small improvement, removes an overly SHOUTY string in favor of a more subtle one.