### PR TITLE
Do not construct request with used request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ SPDX-License-Identifier: BSD-3-Clause
 
 # w3c/vc-test-suite-implementations  ChangeLog
 
-## 2.0.0 - yyyy-mm-dd
+## 2.0.1 - 2024-10-31
+
+### Fixed
+- Code for sanitizing request headers is more resilient.
+
+## 2.0.0 - 2024-07-13
 
 ### Added
 - Support for a new `localConfig.cjs` feature.

--- a/lib/requests.js
+++ b/lib/requests.js
@@ -50,12 +50,12 @@ export async function makeHttpsRequest({
       body, method, json, headers, agent, searchParams
     });
   } catch(e) {
-    error = _sanitizeErrorHeaders({error: e});
+    error = _sanitizeError({error: e});
   }
   const {data, statusCode} = _getDataAndStatus({result, error});
   // if a result is returned sanitize it
   if(result) {
-    result = _sanitizeResponseHeaders({response: result, data});
+    result = _sanitizeResponse({response: result, data});
   }
   return {result, error, data, statusCode};
 }
@@ -91,12 +91,12 @@ export async function zcapRequest({
       capability
     });
   } catch(e) {
-    error = _sanitizeErrorHeaders({error: e});
+    error = _sanitizeError({error: e});
   }
   const {data, statusCode} = _getDataAndStatus({result, error});
   // if a result is returned sanitize it
   if(result) {
-    result = _sanitizeResponseHeaders({response: result, data});
+    result = _sanitizeResponse({response: result, data});
   }
   return {result, error, data, statusCode};
 }
@@ -123,35 +123,20 @@ function _getDataAndStatus({result = {}, error = {}}) {
   return {data, statusCode};
 }
 
-function _sanitizeErrorHeaders({error}) {
+function _sanitizeError({error}) {
   if(error.response) {
-    error.response = _sanitizeResponseHeaders({
+    error.response = _sanitizeResponse({
       response: error.response,
       data: error.data
     });
   }
   if(error.request) {
-    // get the url and the remaining properties from the request
-    const {url, ...props} = error.request;
-    // create an options object to pass to the new request
-    const options = {};
-    // do not copy these properties from the request
-    const skipKeys = new Set(['body', 'headers']);
-    for(const key in props) {
-      if(skipKeys.has(key)) {
-        continue;
-      }
-      options[key] = error.request[key];
-    }
-    error.request = new global.Request(url, {
-      ...options,
-      headers: _sanitizeHeaders({httpMessage: error.request})
-    });
+    error.request = _sanitizeRequest({request: error.request});
   }
   return error;
 }
 
-function _sanitizeResponseHeaders({response, data}) {
+function _sanitizeResponse({response, data}) {
   const newResponse = new global.Response(JSON.stringify(data), {
     headers: _sanitizeHeaders({httpMessage: response}),
     status: response.status,
@@ -163,6 +148,25 @@ function _sanitizeResponseHeaders({response, data}) {
     Object.defineProperty(newResponse, 'data', {value: data});
   }
   return newResponse;
+}
+
+function _sanitizeRequest({request}) {
+  // get the url and the remaining properties from the request
+  const {url, ...props} = request;
+  // create an options object to pass to the new request
+  const options = {};
+  // do not copy these properties from the request
+  const skipKeys = new Set(['body', 'headers']);
+  for(const key in props) {
+    if(skipKeys.has(key)) {
+      continue;
+    }
+    options[key] = request[key];
+  }
+  return new global.Request(url, {
+    ...options,
+    headers: _sanitizeHeaders({httpMessage: request})
+  });
 }
 
 /**

--- a/lib/requests.js
+++ b/lib/requests.js
@@ -131,7 +131,20 @@ function _sanitizeErrorHeaders({error}) {
     });
   }
   if(error.request) {
-    error.request = new global.Request(error.request, {
+    // get the url and the remaining properties from the request
+    const {url, ...props} = error.request;
+    // create an options object to pass to the new request
+    const options = {};
+    // do not copy these properties from the request
+    const skipKeys = new Set(['body', 'headers']);
+    for(const key in props) {
+      if(skipKeys.has(key)) {
+        continue;
+      }
+      options[key] = error.request[key];
+    }
+    error.request = new global.Request(url, {
+      ...options,
       headers: _sanitizeHeaders({httpMessage: error.request})
     });
   }


### PR DESCRIPTION
Changes for sanitizing Requests to be more resilient and less likely to result in used Request errors.