### PR TITLE
Add run in docker instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+localConfig.yml

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,33 @@
+<!--
+Copyright 2024 Digital Bazaar, Inc.
+
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
+# Testing in docker
+
+To run your implementation against all test suites from one location, you can use this docker-compose project.
+
+## Pre requisites
+- [Docker](https://docs.docker.com/compose/install/)
+
+## Setup
+
+Make sure you are in the `docker` directory, then copy the `localConfig` example file:
+```bash
+cd ./docker
+cp localConfig.example.yml localConfig.yml
+```
+Edit the local config details to match your implementation.
+
+Once you are done, you can run the test-suites with:
+```bash
+docker compose up --build
+```
+
+When the tests are completed, you will be able to access the reports in your browser:
+- [vc-data-model-v2](http://vc-data-model.docker.localhost/)
+- [vc-bitstring-status-list](http://vc-bitstring-status-list.docker.localhost/)
+- [vc-di-eddsa](http://vc-di-eddsa.docker.localhost/)
+- [vc-di-ecdsa](http://vc-di-ecdsa.docker.localhost/)
+- [vc-di-bbs](http://vc-di-bbs.docker.localhost/)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,32 @@
+---
+include:
+  - localConfig.yml
+services:
+  vc-data-model-v2:
+    build: https://github.com/w3c/vc-data-model-2.0-test-suite.git#allure-in-docker
+    command: 
+      - /bin/bash
+      - -c
+      - |
+        npm t
+        serve -p 8000 reports/
+    configs:
+      - source: localConfig.cjs
+        target: /test-suite/localConfig.cjs
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.vc-data-model.rule=Host(`vc-data-model.docker.localhost`)
+      - traefik.http.routers.vc-data-model.entrypoints=web
+      - traefik.http.services.vc-data-model.loadbalancer.server.port=8000
+
+  traefik:
+    image: traefik:v3.1
+    command:
+      - --api.insecure=true
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entryPoints.web.address=:80
+    ports:
+      - 80:80
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/docker/localConfig.example.yml
+++ b/docker/localConfig.example.yml
@@ -1,0 +1,34 @@
+
+configs:
+  localConfig.cjs:
+    content: |
+      const baseUrl = process.env.BASE_URL || 'http://implementation:8000';
+      module.exports = {
+        settings: {},
+        implementations: [
+          {
+            name: 'My Company',
+            implementation: 'My Implementation Name',
+            issuers: [
+              {
+                id: '',
+                endpoint: `${baseUrl}/credentials/issue`,
+                options: {},
+                tags: ['vc2.0']
+              }
+            ],
+            verifiers: [{
+              id: '',
+              endpoint: `${baseUrl}/credentials/verify`,
+              options: {},
+              tags: ['vc2.0']
+            }],
+            vpVerifiers: [{
+              id: '',
+              endpoint: `${baseUrl}/presentations/verify`,
+              options: {},
+              tags: ['vc2.0']
+            }]
+          }
+        ]
+      };


### PR DESCRIPTION
Adds a docker-compose file and some instructions.

This enables implementers to run all test suites against their implementation instead of having to clone individual repositories. This is similar to run against a local instance.